### PR TITLE
Hijack `path.resolve()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,5 @@
     "test": "npm run unit",
     "unit": "nyc mocha"
   },
-  "version": "5.0.0"
+  "version": "6.0.0"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -40,4 +40,5 @@ if (makeLong) {
 } else {
 	fix(path, "_makeLong");
 }
+fix(process, "chdir");
 module.exports = fs;

--- a/src/win32-resolve.js
+++ b/src/win32-resolve.js
@@ -1,0 +1,29 @@
+"use strict";
+const gitWin = require("git-win");
+const path = require("path");
+const rawResolve = path.resolve;
+
+function isAbsolute (file) {
+	return (
+		file === "/" ||
+		/^\/+(?:boot|dev|etc|home|init|lib\d*|media|mingw\d+|mnt|opt|proc|root|run|s?bin|snap|srv|sys|tmp|usr|var)(?=\/|$)/.test(file)
+	);
+}
+
+function resolve () {
+	const args = arguments;
+	for (let i = args.length - 1; i >= 0; i--) {
+		if (typeof args[i] !== "string" || args[i].indexOf("\\") >= 0) {
+			break;
+		} else if (path.posix.isAbsolute(args[i])) {
+			const absPath = Array.prototype.slice.call(args, i).join("/");
+			if (!i || isAbsolute(absPath)) {
+				return gitWin.toWin32(absPath);
+			}
+			break;
+		}
+	}
+	return rawResolve.apply(path, args);
+};
+
+path.resolve = resolve;

--- a/src/wsl-resolve.js
+++ b/src/wsl-resolve.js
@@ -1,0 +1,21 @@
+"use strict";
+const wslpath = require("./wslpath");
+const path = require("path");
+const rawResolve = path.resolve;
+
+function resolve () {
+	const args = arguments;
+	for (let i = args.length - 1; i >= 0; i--) {
+		if (typeof args[i] !== "string" || path.posix.isAbsolute(args[i])) {
+			break;
+		} else if (path.win32.isAbsolute(args[i])) {
+			const absPath = wslpath(Array.prototype.slice.call(args, i).join("\\"));
+			if (absPath) {
+				return absPath;
+			}
+			break;
+		}
+	}
+	return rawResolve.apply(path, args);
+};
+path.resolve = resolve;

--- a/src/wslpath.js
+++ b/src/wslpath.js
@@ -1,0 +1,39 @@
+"use strict";
+const cp = require("child_process");
+let driverPrefix = cp.spawnSync("wslpath", ["C:/"], {
+	encoding: "utf8",
+}).stdout;
+if (driverPrefix) {
+	driverPrefix = driverPrefix.replace(/\/c\/\s*$/i, "/");
+} else {
+	driverPrefix = "/mnt/";
+}
+
+function getCurrDriver () {
+	const driver = process.cwd();
+	if (driver.length > driverPrefix.length && driver.startsWith(driverPrefix)) {
+		const suffix = driver[driverPrefix.length + 1];
+		if (!suffix || suffix === "/") {
+			return driver[driverPrefix.length];
+		}
+	}
+}
+
+function wslpath (file) {
+	let driver = /^[A-Z]:+(?=\\|\/)/i.exec(file);
+	if (driver) {
+		file = file.slice(driver[0].length);
+		driver = driver[0][0];
+	} else if (file[0] === "\\") {
+		driver = getCurrDriver();
+		if (!driver) {
+			return;
+		}
+	} else {
+		return;
+	}
+
+	return driverPrefix + driver.toLowerCase() + file.replace(/[\\/]+/g, "/").replace(/\/+$/, "");
+}
+
+module.exports = wslpath;


### PR DESCRIPTION
Hijack `process.chdir()`
Hijack `path.resolve()` for win32 and WSL